### PR TITLE
Empty TextView Delete

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -75,7 +75,7 @@
         android:layout_width="367dp"
         android:layout_height="434dp"
         android:scrollbars="vertical"
-        android:text="TextView"
+        android:text=""
         app:layout_constraintBottom_toBottomOf="@+id/addAlarm"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
On the landing page, there is a "textview" text entry next to the TimeZone button, this seems unnecessary. 